### PR TITLE
docs: documentar componentes y enlazar guías

### DIFF
--- a/FLOW_CREATION_GUIDE.md
+++ b/FLOW_CREATION_GUIDE.md
@@ -1,10 +1,14 @@
 # Guía para construir un flow
 
 Esta guía describe el proceso completo para crear un nuevo *flow* dentro del repositorio, desde la ideación hasta la validación. Un flow es la pieza que orquesta transformadores y grupos de agentes para preparar contexto, activar metas y devolver artefactos finales.
+> Consulta también las guías específicas en `docs/components/` para profundizar en cada artefacto: [manifest](docs/components/manifest.md), [files](docs/components/files.md), [goals](docs/components/goals.md), [flows](docs/components/flows.md), [groups](docs/components/groups.md) y [squads](docs/components/squads.md).
+
 
 ## 1. Comprende el ecosistema
 
 Antes de empezar confirma cómo se relacionan los componentes:
+
+Para una visión más detallada de cada componente revisa las guías en `docs/components`: [flows](docs/components/flows.md), [goals](docs/components/goals.md), [groups](docs/components/groups.md), [squads](docs/components/squads.md) y [files](docs/components/files.md).
 
 - Un **flow** reúne entradas y define las etapas secuenciales a ejecutar.
 - Cada flow delega el objetivo principal en un **group**, el cual enlaza una meta (`goal`) y uno o varios escuadrones (`squads`). 【F:components/groups/figma-to-user-story/v0.0.1/group.yaml†L1-L6】
@@ -21,6 +25,8 @@ Documentar esta intención facilita diseñar la secuencia de etapas y detectar a
 
 ## 3. Prepara entradas y variables
 
+> Amplía los detalles sobre archivos compartidos en [docs/components/files.md](docs/components/files.md).
+
 - Si necesitas nuevos archivos, agrégalos a `components/files/<carpeta>` y actualiza `control.json` para que estén disponibles en `/source_code_files/...`.
 - Define qué valores dinámicos recibirá el flow cuando se ejecute (por ejemplo, rutas de imagen o ubicaciones de salida). Cada valor será una variable del flow con un tipo (`file`, `string`, etc.). En `figma-to-user-story` se declaran tanto la ruta de la imagen Figma como la carpeta donde guardar la historia. 【F:components/flows/figma-to-user-story/v0.0.1/flow.yaml†L4-L8】
 
@@ -31,6 +37,8 @@ Documentar esta intención facilita diseñar la secuencia de etapas y detectar a
 3. Dentro de esa carpeta crea `flow.yaml`. El repositorio sigue un esquema de versionado por carpeta, por lo que futuros cambios convivirán en carpetas adicionales (`v0.0.2`, `v1.0.0`, ...).
 
 ## 5. Redacta el `flow.yaml`
+
+> La estructura completa del `flow.yaml` está documentada en [docs/components/flows.md](docs/components/flows.md).
 
 ### 5.1 Encabezado obligatorio
 
@@ -69,6 +77,8 @@ Añade una etapa con `target_type: group` que pase al grupo toda la información
 - `pre_stages`, `post_stages` y `output_values` están disponibles si requieres preparar o limpiar resultados alrededor de la lista principal de stages. 【F:components/flows/generate-angular-code/v0.0.1/flow.yaml†L6-L16】
 
 ## 6. Verifica la alineación con goal y squad
+
+Para profundizar en cómo diseñar metas, grupos y escuadrones revisa [goals](docs/components/goals.md), [groups](docs/components/groups.md) y [squads](docs/components/squads.md).
 
 - Confirma que el grupo referenciado por el flow expone el goal correcto y que el goal espera exactamente las variables que estás enviando (nombres y tipos deben coincidir). 【F:components/flows/figma-to-user-story/v0.0.1/flow.yaml†L81-L86】【F:components/goals/figma-to-user-story/v0.0.1/goal.yaml†L4-L59】
 - Revisa que el squad asociado cuente con los roles y herramientas necesarios para cumplir el objetivo. Ajusta sus instrucciones si introduces nuevos formatos de entrega.

--- a/docs/components/files.md
+++ b/docs/components/files.md
@@ -1,0 +1,48 @@
+# Archivos de contexto (`components/files`)
+
+## Propósito
+Este componente empaqueta artefactos de apoyo (documentos, imágenes, guías) que los flows montan en el runtime. Cada archivo se versiona por carpeta funcional y queda disponible mediante rutas `/source_code_files/...` definidas en `control.json`. 【F:components/files/control.json†L1-L184】
+
+## Estructura de carpetas
+```
+components/files/
+  <colección>/
+    input/
+      <archivo>
+    output/
+      <artefactos-generados>
+  control.json
+```
+- Cada colección agrupa entradas relacionadas con un flujo o contexto (por ejemplo `1-context-engineering` o `adl-user-story-to-implementation-plan`).
+- Las carpetas `input` contienen fuentes que se copiarán al contenedor de ejecución; `output` sirve como destino cuando goals o squads guardan resultados (no se listan en `control.json`).
+
+## `control.json`
+El archivo `control.json` es un arreglo de objetos que describe cada recurso disponible.
+```json
+{
+  "name": "angular-manual.md",
+  "description": "Angular manual",
+  "file": "1-context-engineering/input/angular-manual.md",
+  "mime_type": "text/markdown",
+  "rag": true,
+  "dest_dir": "/source_code_files/1-context-engineering/input"
+}
+```
+- `file` es la ruta relativa dentro de `components/files`. 【F:components/files/control.json†L1-L33】
+- `dest_dir` indica la carpeta destino que verá el agente (usada por transformadores como `get_file_content`).
+- `rag` activa si un archivo debe indexarse para recuperación aumentada.
+
+## Relaciones con otros componentes
+- Los flows leen estos archivos con transformadores; por ejemplo `angular-code-plan` consume PRD y especificaciones definidas aquí. 【F:components/flows/angular-code-plan/v0.0.1/flow.yaml†L5-L88】
+- Los goals hacen referencia a rutas de salida que existen en estas colecciones (p.ej. `2-angular-code-plan/output/angular-code-plan.md`). 【F:components/goals/angular-code-plan/v0.0.1/goal.yaml†L42-L66】
+
+## Listas de verificación
+### Creación / incorporación de nuevos archivos
+- [ ] Copiar los archivos fuente dentro de una carpeta funcional (`input/`).
+- [ ] Registrar cada recurso en `control.json` con `dest_dir` coherente.
+- [ ] Confirmar que los flows o goals hacen referencia a la ruta montada (`/source_code_files/...`).
+
+### Mantenimiento
+- [ ] Actualizar `description` y `rag` cuando cambie el propósito o la indexación requerida.
+- [ ] Versionar colecciones creando nuevas carpetas (por ejemplo `v0.0.2/input/`) si la estructura de archivos cambia de forma incompatible.
+- [ ] Eliminar entradas de `control.json` sólo después de remover todas las referencias en flows o goals.

--- a/docs/components/flows.md
+++ b/docs/components/flows.md
@@ -1,0 +1,54 @@
+# Flows (`components/flows`)
+
+## Propósito
+Los flows orquestan transformadores y grupos para preparar contexto, delegar objetivos y producir entregables. Son el punto de entrada operativo del sistema: definen el orden de ejecución, las variables de entrada y cómo se conectan con goals y squads.
+
+## Estructura YAML
+```yaml
+flow:
+  id: <uuid>
+  name: <slug>
+  version: <semver>
+  description: <opcional>
+  variables:
+    - name: <variable>
+      type: <file|string|...>
+  pre_stages: []        # opcional
+  stages:
+    - name: <etapa>
+      comment: <opcional>
+      target_type: transformer|group
+      target_name: <componente>
+      target_version: <semver>
+      iterator: <ref>              # opcional
+      iterator_parallelism: <n>
+      input_values:
+        - <clave>: <valor|*_ref>
+      output_values: []            # opcional
+  post_stages: []       # opcional
+```
+Ejemplos completos: `components/flows/angular-code-plan/v0.0.1/flow.yaml` y `components/flows/generate-angular-code/v0.0.1/flow.yaml`. 【F:components/flows/angular-code-plan/v0.0.1/flow.yaml†L1-L95】【F:components/flows/generate-angular-code/v0.0.1/flow.yaml†L1-L18】
+
+## Campos críticos
+- `name` y `version` determinan la carpeta y las referencias en otras piezas.
+- `variables` declara cada entrada dinámica que el runtime debe inyectar (rutas, strings, etc.). Deben alinearse con los marcadores `{{variable}}` utilizados en el goal asociado.
+- `stages` define la secuencia: las primeras etapas suelen leer archivos (`get_file_content`) y preparar strings (`escape_angular_template`) antes de invocar al grupo.
+- `target_type: group` es obligatorio en la etapa que delega el objetivo principal. El `target_name` debe coincidir con `components/groups/<nombre>/<versión>/group.yaml`.
+
+## Relaciones con otros componentes
+- Las variables declaradas se convierten en insumos que el goal espera. Ejemplo: el flow `angular-code-plan` envía `prd_content`, `figma_design_specifications`, etc., que el goal usa dentro de su `objective`. 【F:components/flows/angular-code-plan/v0.0.1/flow.yaml†L80-L88】【F:components/goals/angular-code-plan/v0.0.1/goal.yaml†L14-L63】
+- Cada flow invoca un `group` específico (`target_type: group`). Ese group referencia un `goal` y los `squads` que ejecutarán la meta. 【F:components/flows/angular-code-plan/v0.0.1/flow.yaml†L80-L88】【F:components/groups/angular-code-plan/v0.0.1/group.yaml†L1-L6】
+- Los flows dependen de los archivos listados en `components/files/control.json`; las etapas de lectura deben apuntar a rutas válidas. 【F:components/files/control.json†L1-L184】
+
+## Listas de verificación
+### Creación / nueva versión
+- [ ] Crear carpeta `components/flows/<nombre>/<versión>/` siguiendo semántica de versionado.
+- [ ] Generar `id` nuevo (UUID) si se publica una versión mayor.
+- [ ] Definir variables de entrada y confirmar que los goals asociados referencian exactamente esos nombres.
+- [ ] Documentar cada etapa con comentarios si agrega transformaciones no triviales.
+- [ ] Incluir etapa final con `target_type: group` apuntando al group vigente.
+
+### Mantenimiento
+- [ ] Actualizar rutas absolutas cuando cambien archivos en `components/files` y sincronizar `control.json`.
+- [ ] Incrementar versión al introducir cambios incompatibles (nuevas variables, reordenamiento de stages, etc.). Mantén la versión previa para compatibilidad.
+- [ ] Revisar que cualquier cambio en `target_version` de transformadores o grupos exista en el repositorio.

--- a/docs/components/goals.md
+++ b/docs/components/goals.md
@@ -1,0 +1,42 @@
+# Goals (`components/goals`)
+
+## Propósito
+Los goals encapsulan la misión que deberán cumplir los squads: definen instrucciones, contexto y variables que recibirán los agentes. Funcionan como contrato entre los flows (que preparan los datos) y los grupos/squads (que ejecutan la tarea). 【F:components/goals/angular-code-plan/v0.0.1/goal.yaml†L1-L69】
+
+## Estructura YAML
+```yaml
+goal:
+  id: <uuid>
+  name: <slug>
+  version: <semver>
+  display_name: <nombre legible>
+  description: <opcional>
+  objective: |-
+    ... instrucciones con {{variables}}
+  startpoint: |-
+    ... sugerencia inicial para el planner
+```
+- `objective` contiene el prompt principal con marcadores `{{variable}}` que deben coincidir con los nombres enviados desde el flow.
+- `startpoint` describe el primer paso sugerido para el planner del squad.
+
+## Campos críticos
+- `objective`: debe enumerar claramente contexto, entradas, pasos y criterios de aceptación. Ejemplo: `angular-code-plan` lista PRD, especificaciones y ruta de salida. 【F:components/goals/angular-code-plan/v0.0.1/goal.yaml†L14-L63】
+- `version`: se alinea con la carpeta `components/goals/<nombre>/<versión>/` y con referencias `goal_ref` en grupos.
+- `name`: usado por flows y groups para enlazar el goal (`goal_ref: <name>@<versión>`).
+
+## Relaciones con otros componentes
+- El flow es responsable de poblar cada `{{variable}}` antes de invocar al group; si faltan, el goal quedará con marcadores sin resolver. 【F:components/flows/angular-code-plan/v0.0.1/flow.yaml†L80-L88】
+- Los groups enlazan el goal mediante `goal_ref`, asegurando que los squads trabajen con la versión correcta. 【F:components/groups/generate-angular-code/v0.0.1/group.yaml†L9-L24】
+- Los squads reciben el `objective` como parte del contexto operativo cuando el group los activa, por lo que cualquier cambio debe comunicarse en sus instrucciones si afecta el flujo de trabajo. 【F:components/squads/generate-angular-code/v0.0.1/squad.yaml†L1-L126】
+
+## Listas de verificación
+### Creación / nueva versión
+- [ ] Crear carpeta `components/goals/<nombre>/<versión>/` y generar `id` nuevo si es una versión incompatible.
+- [ ] Redactar `objective` con secciones claras: contexto, entradas, pasos, criterios de aceptación y rutas de salida.
+- [ ] Confirmar que todas las variables declaradas en el texto (`{{variable}}`) tengan equivalentes en el flow correspondiente.
+- [ ] Actualizar `startpoint` para guiar al planner acorde a la complejidad del objetivo.
+
+### Mantenimiento
+- [ ] Incrementar versión cuando cambien instrucciones o variables de forma incompatible con flows existentes.
+- [ ] Revisar que `goal_ref` de los groups apunten a la versión correcta tras cualquier actualización. 【F:components/groups/generate-angular-code/v0.0.1/group.yaml†L9-L24】
+- [ ] Alinear instrucciones de squads con nuevos pasos o criterios definidos en el goal.

--- a/docs/components/groups.md
+++ b/docs/components/groups.md
@@ -1,0 +1,50 @@
+# Groups (`components/groups`)
+
+## Propósito
+Un group es el puente entre un flow y los squads que ejecutan el goal. Define cómo se coordina la conversación (tipo de chat, planner, límites), referencia la meta (`goal_ref`) y lista los escuadrones que participarán (`squads`). 【F:components/groups/generate-angular-code/v0.0.1/group.yaml†L1-L27】
+
+## Estructura YAML
+```yaml
+group:
+  id: <uuid>
+  name: <slug>
+  version: <semver>
+  display_name: <opcional>
+  description: <opcional>
+  chat_type: round-robin|broadcast|...
+  chat_allow_repeat_speakers: <bool>
+  planner_role: <mensaje>
+  planner_guidance: |-
+    ...
+  goal_ref: <goal>@<versión>
+  squads:
+    - squad_ref: <squad>@<versión>
+  max_rounds: <n>
+  term_regexes:
+    - ^\s*TERMINATE\s*$
+```
+La definición puede incluir configuraciones adicionales como `capabilities`, `input_keys`, `enable_memory` o `term_regex_flags` dependiendo de las necesidades del orquestador.
+
+## Campos críticos
+- `goal_ref`: enlace directo al goal que describe la misión. Debe coincidir con una carpeta existente en `components/goals/<goal>/<versión>/`.
+- `squads`: lista de referencias `squad_ref` que participarán; cada entrada usa el formato `<nombre>@<versión>`.
+- `planner_guidance` y `planner_role`: instrucciones con las que inicia el agente planner; deben estar alineadas con el `startpoint` del goal.
+- `max_rounds` y `term_regexes`: controlan la finalización de la sesión.
+
+## Relaciones con otros componentes
+- Los flows llaman al group mediante `target_type: group`, por lo que `name` y `version` deben coincidir con lo declarado en la etapa correspondiente. 【F:components/flows/generate-angular-code/v0.0.1/flow.yaml†L9-L16】
+- El group consume el goal indicado en `goal_ref`; cualquier cambio de versión requiere actualizar flows y squads asociados. 【F:components/goals/generate-angular-code/v0.0.1/goal.yaml†L1-L27】
+- Cada `squad_ref` debe existir y contener agentes configurados para cumplir el objetivo. 【F:components/squads/generate-angular-code/v0.0.1/squad.yaml†L1-L146】
+
+## Listas de verificación
+### Creación / nueva versión
+- [ ] Crear carpeta `components/groups/<nombre>/<versión>/group.yaml` y generar un `id` único.
+- [ ] Establecer `goal_ref` apuntando a la versión del goal que utilizará el flow.
+- [ ] Enumerar todos los `squad_ref` necesarios y verificar que existan.
+- [ ] Ajustar `planner_guidance` para reflejar el `objective` y `startpoint` del goal.
+- [ ] Definir reglas de terminación (`term_regexes`) acordes al comportamiento esperado.
+
+### Mantenimiento
+- [ ] Sincronizar `goal_ref` y `squad_ref` cuando se publiquen nuevas versiones de goals o squads.
+- [ ] Actualizar `max_rounds`, roles o instrucciones si cambian los tiempos de ejecución o protocolos de colaboración.
+- [ ] Versionar el group cuando los cambios impacten compatibilidad (por ejemplo, añadir/quitar squads o modificar drásticamente la guía del planner).

--- a/docs/components/manifest.md
+++ b/docs/components/manifest.md
@@ -1,0 +1,44 @@
+# Manifest de componentes
+
+## Propósito
+El manifiesto centraliza los metadatos del paquete de componentes (nombre, autoría, versión) y declara las configuraciones de modelos disponibles para squads y transformadores. Sirve como punto único para sincronizar identificadores de modelos y credenciales utilizadas en `groups`, `squads` o transformadores que hagan referencia a `llm_config`. 【F:components/manifest.yaml†L1-L63】
+
+## Estructura YAML
+```yaml
+components:
+  manifest_version: "0.1"
+  metadata:
+    name: <slug>
+    version: <semver>
+    author: <equipo>
+    description: <resumen>
+    llm_configs:
+      - name: <proveedor:modelo>
+        model_client: <clase>
+        configuration:
+          <clave>: <valor>
+```
+
+- La raíz `components` agrupa toda la definición. 【F:components/manifest.yaml†L1-L3】
+- `metadata` describe el paquete y se alinea con la convención de versionado por carpeta usada en `components/<tipo>/<nombre>/<versión>/`. 【F:components/manifest.yaml†L4-L8】
+- `llm_configs` lista cada modelo utilizable por squads; el campo `name` se usa como referencia en `llm_config` dentro de stages o agentes. 【F:components/manifest.yaml†L9-L63】
+
+## Campos críticos
+- `manifest_version`: controla compatibilidad con el runtime de orquestación. Actualiza sólo cuando cambien las reglas del esquema.
+- `metadata.version`: debe reflejar la versión global del paquete y mantenerse alineado con carpetas de versión de goals, flows, groups y squads.
+- `llm_configs[*].name`: referencia utilizada en `components/flows/angular-code-plan/v0.0.1/flow.yaml` al invocar transformadores (`llm_config: azure:gpt-4o`). Cualquier cambio requiere actualizar todas las referencias. 【F:components/flows/angular-code-plan/v0.0.1/flow.yaml†L34-L47】
+
+## Relaciones con otros componentes
+- Los `llm_configs` proveen las etiquetas que squads usan en los agentes (`model: azure:gpt-4.1-mini` en `components/squads/generate-angular-code/v0.0.1/squad.yaml`). 【F:components/squads/generate-angular-code/v0.0.1/squad.yaml†L64-L66】
+- Cambios en `metadata.version` o `llm_configs` pueden requerir regenerar IDs en goals/grupos si se versiona el paquete completo.
+
+## Listas de verificación
+### Creación / versión inicial
+- [ ] Definir `metadata` con nombre único, autoría y descripción resumida.
+- [ ] Registrar todos los modelos que usarán agentes o transformadores del paquete.
+- [ ] Validar credenciales y campos obligatorios (`api_key`, `azure_endpoint`, etc.) según cada `model_client`.
+
+### Mantenimiento
+- [ ] Incrementar `metadata.version` cuando se publique una versión que incluya cambios incompatibles o relevantes en cualquier componente.
+- [ ] Añadir nuevos `llm_configs` antes de referenciarlos en squads o flows; eliminar sólo tras reemplazar sus usos.
+- [ ] Revisar periódicamente que los nombres declarados sigan disponibles en los entornos cloud correspondientes.

--- a/docs/components/squads.md
+++ b/docs/components/squads.md
@@ -1,0 +1,56 @@
+# Squads (`components/squads`)
+
+## Propósito
+Los squads describen a los agentes que colaborarán para cumplir un goal: roles, modelos, herramientas, guías y restricciones. Actúan como plantilla operativa activada por un group. 【F:components/squads/generate-angular-code/v0.0.1/squad.yaml†L1-L146】
+
+## Estructura YAML
+```yaml
+squad:
+  id: <uuid>
+  name: <slug>
+  version: <semver>
+  display_name: <opcional>
+  description: <opcional>
+  model: <llm-config-por-defecto>
+  chat_type: <opcional>
+  chat_allow_repeat_speakers: <bool>
+  term_regexes:
+    - ^WELL_DONE_TEAM$
+  agents:
+    - name: <rol>
+      display_name: <visible>
+      leader: <bool>
+      model: <llm-config>
+      guidance: |-
+        ...
+      tools:
+        - save_file
+      talk_with:
+        - planner
+      user_proxy: <bool>
+```
+Cada agente puede declarar `human_cost_per_hour`, `human_time_multiplyer`, `code_execution`, `term_regexes` y otras restricciones adicionales.
+
+## Campos críticos
+- `agents[*].model`: debe coincidir con un `llm_configs.name` definido en `components/manifest.yaml`.
+- `leader: true` determina quién puede terminar la sesión; sus instrucciones deben alinearse con el `startpoint` del goal.
+- `tools` habilitan acciones clave (por ejemplo `save_file`). Asegúrate de incluir las herramientas necesarias para cumplir los criterios del goal.
+- `term_regexes` del squad controlan palabras clave de finalización; deben concordar con las instrucciones del planner (`WELL_DONE_TEAM`, etc.).
+
+## Relaciones con otros componentes
+- Los groups referencian squads mediante `squad_ref`. Cada versión nueva debe registrarse allí. 【F:components/groups/generate-angular-code/v0.0.1/group.yaml†L18-L24】
+- Las instrucciones y roles deben respaldar el `objective` del goal; por ejemplo, el `planner` guía al equipo para generar código definido en el goal `generate-angular-code`. 【F:components/goals/generate-angular-code/v0.0.1/goal.yaml†L1-L27】【F:components/squads/generate-angular-code/v0.0.1/squad.yaml†L6-L110】
+- Los flows dependen de que los squads manejen las variables entregadas a través del group, por lo que cualquier cambio en herramientas o comunicación debe reflejarse en la documentación del flow.
+
+## Listas de verificación
+### Creación / nueva versión
+- [ ] Crear carpeta `components/squads/<nombre>/<versión>/squad.yaml` con `id` nuevo si hay cambios incompatibles.
+- [ ] Definir roles necesarios (planner, especialistas, critic, user_proxy, etc.) y sus permisos.
+- [ ] Asignar modelos disponibles en el manifiesto y verificar que soporten las herramientas declaradas.
+- [ ] Redactar guías detalladas para cada agente, alineadas con el goal correspondiente.
+- [ ] Configurar `term_regexes` y herramientas clave (`save_file`, `read_file`, `submit_question`, etc.).
+
+### Mantenimiento
+- [ ] Actualizar `guidance`, `tools` o `model` cuando cambien los procesos o capacidades requeridas.
+- [ ] Incrementar versión y sincronizar `squad_ref` en groups si se modifica la composición del equipo.
+- [ ] Revisar que el agente líder conserve la autoridad de terminación y que la palabra clave siga alineada con las instrucciones del goal.


### PR DESCRIPTION
## Summary
- agregar documentación por tipo de componente en `docs/components/*`
- detallar relaciones entre goals, flows, groups, squads y archivos de soporte
- enlazar las nuevas guías desde `FLOW_CREATION_GUIDE.md`

## Testing
- not run (documentación)

------
https://chatgpt.com/codex/tasks/task_e_68cb60da158483318df1d1fad8ba46cc